### PR TITLE
allow for curriculum view even when none are loaded

### DIFF
--- a/src/app/routes/curriculum-editor/curriculum-editor.component.html
+++ b/src/app/routes/curriculum-editor/curriculum-editor.component.html
@@ -62,7 +62,7 @@
       </mat-tab-group>
 
     </div>
-    <div class="col-sm-auto mt-2" *ngIf="selectedCurriculum">
+    <div class="col-sm-auto mt-2 curriculum-view">
       <app-curriculum-view [curriculum]='selectedCurriculum'></app-curriculum-view>
     </div>
   </div>

--- a/src/app/routes/curriculum-editor/curriculum-view/curriculum-view.component.css
+++ b/src/app/routes/curriculum-editor/curriculum-view/curriculum-view.component.css
@@ -1,0 +1,5 @@
+.currV {
+  display: flex;
+  flex-direction: column;
+  max-width:1010px;
+}

--- a/src/app/routes/curriculum-editor/curriculum-view/curriculum-view.component.html
+++ b/src/app/routes/curriculum-editor/curriculum-view/curriculum-view.component.html
@@ -1,4 +1,5 @@
-<mat-card *ngIf="curriculum">
+<div class="currV">
+  <mat-card *ngIf="curriculum; else defaultView">
     <mat-card-header>
       <mat-toolbar class="panel-bar">
         <h3 class="m-0 p-0">Curriculum View: {{curriculum.name}}</h3>
@@ -9,9 +10,22 @@
         </span>
       </mat-toolbar>
     </mat-card-header>
-    <mat-card-content style="overflow: auto; height: 470px;" *ngIf="curriculum.curriculumWeeks">
+    <mat-card-content style="overflow: auto; height: 400px;" *ngIf="curriculum.curriculumWeeks">
       <span *ngFor="let week of curriculum.curriculumWeeks">
         <app-curriculum-week [week]='week' (weekChange)='onWeekChange($event)'></app-curriculum-week>
       </span>
     </mat-card-content>
   </mat-card>
+  <ng-template #defaultView>
+    <mat-card>
+      <mat-card-header>
+        <mat-toolbar class="panel-bar">
+          <h3 class="m-0 p-0">Curriculum View</h3>
+        </mat-toolbar>
+      </mat-card-header>
+      <mat-card-content style="overflow: auto; height: 400px; width: 800px;">
+      </mat-card-content>
+    </mat-card>
+  </ng-template>
+  
+</div>


### PR DESCRIPTION
Fixes blank curriculum view on initial load of page. Curriculum view better aligns with curriculum and topic pool